### PR TITLE
feat :sparkles: add navigation between newsletters

### DIFF
--- a/src/actions/newsletter/get-all-newsletters-ordered-by-month.ts
+++ b/src/actions/newsletter/get-all-newsletters-ordered-by-month.ts
@@ -1,0 +1,16 @@
+import prisma from '@/lib/prisma'
+
+export const getAllNewslettersOrderedByMonth = async () => {
+  try {
+    const newsletters = await prisma.newsletter.findMany({
+      orderBy: { month: 'asc' },
+      select: {
+        title: true
+      }
+    })
+
+    return newsletters
+  } catch (error) {
+    return []
+  }
+}

--- a/src/actions/newsletter/index.ts
+++ b/src/actions/newsletter/index.ts
@@ -1,0 +1,3 @@
+export { getAllNewslettersOrderedByMonth } from './get-all-newsletters-ordered-by-month'
+export { getNewsletterByTitle } from './get-newsletter-by-title'
+export { getNewsletters } from './get-newsletters'


### PR DESCRIPTION
Added navigation buttons for easier access between newsletters in sequence.

- Added getAllNewslettersOrderedByMonth to fetch all newsletter entries.
- Added navigation buttons at the top of the page for "Previous" and "Next" newsletters.