### PR TITLE
chore :gear: add revalidation period to landing page

### DIFF
--- a/src/app/(educational-newsletters)/page.tsx
+++ b/src/app/(educational-newsletters)/page.tsx
@@ -3,6 +3,8 @@ import { getNewsletters } from '@/actions/newsletter/get-newsletters'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'
 
+export const revalidate = 60 * 60 * 24 * 7 // 1 week
+
 export default async function LandingPage() {
   const { newsletters } = await getNewsletters({ page: 1, take: 2 })
 


### PR DESCRIPTION
Added a revalidation interval to the LandingPage component to refresh data weekly.

- Set revalidate constant to one week (60 * 60 * 24 * 7 seconds) to keep newsletter content up-to-date without frequent rebuilds.
- This change optimizes data freshness while reducing unnecessary server load.