### PR TITLE
fix :bug: Update newsletter retrieval to findFirst method

### DIFF
--- a/src/actions/newsletter/get-newsletter-by-title.ts
+++ b/src/actions/newsletter/get-newsletter-by-title.ts
@@ -3,7 +3,7 @@
 import prisma from '@/lib/prisma'
 
 export const getNewsletterByTitle = async (title: string) => {
-  const newsletter = await prisma.newsletter.findUnique({
+  const newsletter = await prisma.newsletter.findFirst({
     where: {
       title
     },


### PR DESCRIPTION
Updated `getNewsletterByTitle` to use `findFirst` instead of `findUnique` to ensure flexibility in title matching, addressing cases where title uniqueness cannot be guaranteed.