### PR TITLE
feat :sparkles: Add grade parameter to newsletter pages

### DIFF
--- a/src/actions/newsletter/get-newsletter-by-title.ts
+++ b/src/actions/newsletter/get-newsletter-by-title.ts
@@ -1,11 +1,13 @@
 'use server'
 
+import { type Grade } from '@/interfaces'
 import prisma from '@/lib/prisma'
 
-export const getNewsletterByTitle = async (title: string) => {
+export const getNewsletterByTitle = async (title: string, grade?: Grade) => {
   const newsletter = await prisma.newsletter.findFirst({
     where: {
-      title
+      title,
+      ...(grade && { grade })
     },
     include: {
       topics: true,

--- a/src/app/(educational-newsletters)/admin/newsletters/[slug]/page.tsx
+++ b/src/app/(educational-newsletters)/admin/newsletters/[slug]/page.tsx
@@ -1,17 +1,23 @@
 import { redirect } from 'next/navigation'
 import NewsletterForm from './FormNewsletter'
 import { getNewsletterByTitle } from '@/actions/newsletter'
+import { convertToGrade } from '@/utils/convertToGrade'
 
 interface Props {
   params: {
     slug: string
   }
+  searchParams: {
+    grade?: string
+  }
 }
 
-export default async function NewsLetterPage({ params }: Props) {
+export default async function NewsLetterPage({ params, searchParams }: Props) {
   const { slug } = params
+  const grade = convertToGrade(searchParams.grade)
+
   const decodedTitle = decodeURIComponent(slug)
-  const { newsletter } = await getNewsletterByTitle(decodedTitle)
+  const { newsletter } = await getNewsletterByTitle(decodedTitle, grade)
 
   if (!newsletter && slug !== 'create') {
     redirect('/admin/newsletters')

--- a/src/app/(educational-newsletters)/admin/newsletters/page.tsx
+++ b/src/app/(educational-newsletters)/admin/newsletters/page.tsx
@@ -11,17 +11,27 @@ import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { type Grade } from '@/interfaces'
+import { convertToGrade } from '@/utils/convertToGrade'
 
 interface Newsletter {
   id: string
   title: string
   month: Date
-  grade: string
+  grade: Grade
 }
 
-export default function NewsletterDashboard() {
+interface Props {
+  searchParams: {
+    grade?: string
+  }
+}
+
+export default function NewsletterDashboard({ searchParams }: Props) {
   const { data: session } = useSession()
   const isAdmin = session?.user?.role === 'admin'
+
+  const grade = convertToGrade(searchParams.grade)
 
   const [newsletters, setNewsletters] = useState<Newsletter[]>([])
   const [filteredNewsletters, setFilteredNewsletters] = useState<Newsletter[]>([])
@@ -41,7 +51,7 @@ export default function NewsletterDashboard() {
     setLoading(true)
     setError(null)
     try {
-      const { newsletters } = await getNewsletters({})
+      const { newsletters } = await getNewsletters({ grade })
       if (!newsletters) {
         setNewsletters([])
         setFilteredNewsletters([])
@@ -227,7 +237,7 @@ export default function NewsletterDashboard() {
                           size="sm"
                           className="mr-2"
                         >
-                          <Link href={`/admin/newsletters/${newsletter.title}`}>
+                          <Link href={`/admin/newsletters/${newsletter.title}?grade=${newsletter.grade}`}>
                             <IoPencil className="h-4 w-4" />
                           </Link>
                         </Button>
@@ -258,10 +268,10 @@ export default function NewsletterDashboard() {
                           )
                         }
                       </div>
-                      <Link href={`/newsletters/${newsletter.title}`}>
+                      <Link href={`/newsletters/${newsletter.title}?grade=${newsletter.grade}`}>
                         <div className="flex items-center justify-between">
                           <p className="text-sm font-medium text-primary truncate">
-                            {newsletter.grade} - {newsletter.title}
+                            {newsletter.title} - {newsletter.grade}
                           </p>
 
                           <div className="ml-2 flex-shrink-0 flex">

--- a/src/app/(educational-newsletters)/newsletters/page.tsx
+++ b/src/app/(educational-newsletters)/newsletters/page.tsx
@@ -170,11 +170,11 @@ export default function NewsletterListPage({ searchParams }: Props) {
                     <p className='text-sm font-medium text-primary truncate px-4 py-4 sm:px-6'>No newsletter found</p>)
                   : (currentItems.map((newsletter) => (
                     <li key={newsletter.id}>
-                      <Link href={`/newsletters/${newsletter.title}`} className="block hover:bg-gray-50">
+                      <Link href={`/newsletters/${newsletter.title}?grade=${newsletter.grade}`} className="block hover:bg-gray-50">
                         <div className="px-4 py-4 sm:px-6">
                           <div className="flex items-center justify-between">
                             <p className="text-sm font-medium text-primary truncate">
-                              {newsletter.grade} {newsletter.title}
+                              {newsletter.title}
                             </p>
                             <div className="ml-2 flex-shrink-0 flex">
                               <p className="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-green-100 text-green-800">

--- a/src/app/(educational-newsletters)/page.tsx
+++ b/src/app/(educational-newsletters)/page.tsx
@@ -45,7 +45,7 @@ export default async function LandingPage() {
                   ))}</p>
                 </CardContent>
                 <CardFooter>
-                  <Link href={`/newsletters/${newsletter.title}`} passHref>
+                  <Link href={`/newsletters/${newsletter.title}?grade=${newsletter.grade}`} passHref>
                     <Button>View More</Button>
                   </Link>
                 </CardFooter>
@@ -60,7 +60,7 @@ export default async function LandingPage() {
                   className='max-w-2xl justify-center flex mx-auto'
                 >
                   <Link href="/newsletters?grade=K2" passHref>
-                    View All Newsletters
+                    View All Newsletters K2
                   </Link>
                 </Button>
               </div>
@@ -90,7 +90,7 @@ export default async function LandingPage() {
                   ))}</p>
                 </CardContent>
                 <CardFooter>
-                  <Link href={`/newsletters/${newsletter.title}`} passHref>
+                  <Link href={`/newsletters/${newsletter.title}?grade=${newsletter.grade}`} passHref>
                     <Button>View More</Button>
                   </Link>
                 </CardFooter>
@@ -105,7 +105,7 @@ export default async function LandingPage() {
                   className='max-w-2xl justify-center flex mx-auto'
                 >
                   <Link href="/newsletters?grade=K3" passHref>
-                    View All Newsletters
+                    View All  K3
                   </Link>
                 </Button>
               </div>

--- a/src/utils/convertToGrade.ts
+++ b/src/utils/convertToGrade.ts
@@ -1,0 +1,14 @@
+import { type Grade } from '@/interfaces'
+
+// Define explicit array of valid Grade values
+const gradeValues: Grade[] = ['K2', 'K3']
+
+// Function to convert string to Grade
+export const convertToGrade = (grade: string | undefined): Grade | undefined => {
+  // Check if the grade is included in the valid values
+  if (grade && gradeValues.includes(grade as Grade)) {
+    return grade as Grade
+  }
+  // Return undefined if the grade is invalid or not provided
+  return undefined
+}

--- a/src/utils/monthColors.ts
+++ b/src/utils/monthColors.ts
@@ -9,6 +9,6 @@ export const monthColors: Record<number, string> = {
   8: 'bg-[#FF3333]',
   9: 'bg-[#004AAD]',
   10: 'bg-[#8C52FF]',
-  11: 'bg-[#FF33D4]',
+  11: 'bg-[#8B2703]',
   12: 'bg-[#33FFA8]'
 }


### PR DESCRIPTION
- Added optional `grade` parameter to `getNewsletterByTitle` and updated associated pages for newsletter retrieval based on grade.
- Implemented `convertToGrade` utility to parse grade from `searchParams`.
- Modified internal links to include `grade` in URL query, ensuring correct filtering and page navigation.
- Updated month colors for visual consistency.