### PR TITLE
feat: :sparkles: Add playlist support to newsletters

### DIFF
--- a/prisma/migrations/20250106223648_add_playlist/migration.sql
+++ b/prisma/migrations/20250106223648_add_playlist/migration.sql
@@ -1,0 +1,12 @@
+-- CreateTable
+CREATE TABLE "playlists" (
+    "id" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "url" TEXT NOT NULL,
+    "newsletterId" TEXT NOT NULL,
+
+    CONSTRAINT "playlists_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "playlists" ADD CONSTRAINT "playlists_newsletterId_fkey" FOREIGN KEY ("newsletterId") REFERENCES "newsletters"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20250106224358_update_relation_playlist/migration.sql
+++ b/prisma/migrations/20250106224358_update_relation_playlist/migration.sql
@@ -1,0 +1,21 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `newsletterId` on the `playlists` table. All the data in the column will be lost.
+  - A unique constraint covering the columns `[playlistId]` on the table `newsletters` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- DropForeignKey
+ALTER TABLE "playlists" DROP CONSTRAINT "playlists_newsletterId_fkey";
+
+-- AlterTable
+ALTER TABLE "newsletters" ADD COLUMN     "playlistId" TEXT;
+
+-- AlterTable
+ALTER TABLE "playlists" DROP COLUMN "newsletterId";
+
+-- CreateIndex
+CREATE UNIQUE INDEX "newsletters_playlistId_key" ON "newsletters"("playlistId");
+
+-- AddForeignKey
+ALTER TABLE "newsletters" ADD CONSTRAINT "newsletters_playlistId_fkey" FOREIGN KEY ("playlistId") REFERENCES "playlists"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20250107114644_update_title_playlist/migration.sql
+++ b/prisma/migrations/20250107114644_update_title_playlist/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "playlists" ALTER COLUMN "title" DROP NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -39,6 +39,8 @@ model Newsletter {
 
   socialSkillId String?      @unique // Foreign key to associate with SocialSkill
   socialSkill   SocialSkill? @relation(fields: [socialSkillId], references: [id], onDelete: Cascade) // Relation 1:1 with SocialSkill (optional)
+  playlistId    String?      @unique // Foreign key to associate with Playlist
+  playlist      Playlist?    @relation(fields: [playlistId], references: [id], onDelete: Cascade) // Relation 1:1 with Playlist (optional)
 
   @@map("newsletters")
 }
@@ -89,6 +91,15 @@ model Video {
   newsletter   Newsletter @relation(fields: [newsletterId], references: [id], onDelete: Cascade)
 
   @@map("videos")
+}
+
+model Playlist {
+  id         String      @id @default(uuid())
+  title      String? // Playlist title (e.g., "October 2024 Videos")
+  url        String // YouTube playlist URL
+  newsletter Newsletter? // Relation 1:1 with Newsletter (optional)
+
+  @@map("playlists")
 }
 
 model User {

--- a/src/actions/newsletter/create-update-newsletter.ts
+++ b/src/actions/newsletter/create-update-newsletter.ts
@@ -38,7 +38,10 @@ const newsletterSchema = z.object({
     by: z.string().min(1, 'Video creator cannot be empty.'),
     url: z.string().url('Must be a valid URL.')
   })),
-  grade: z.enum(['K2', 'K3'])
+  grade: z.enum(['K2', 'K3']),
+  playlist: z.object({
+    url: z.string().url('Must be a valid URL.')
+  })
 })
 
 export const createUpdateNewsletter = async (formData: FormData) => {
@@ -48,6 +51,7 @@ export const createUpdateNewsletter = async (formData: FormData) => {
   const parsedVocabulary = JSON.parse(formData.get('vocabulary') as string)
   const parsedTopics = JSON.parse(formData.get('topics') as string)
   const parsedVideos = JSON.parse(formData.get('videos') as string)
+  const parsedPlaylist = JSON.parse(formData.get('playlist') as string)
 
   const dataToValidate = {
     ...data,
@@ -55,11 +59,14 @@ export const createUpdateNewsletter = async (formData: FormData) => {
     notes: parsedNotes,
     vocabularies: parsedVocabulary,
     topics: parsedTopics,
-    videos: parsedVideos
+    videos: parsedVideos,
+    playlist: parsedPlaylist
   }
 
-  const newsletterParsed = newsletterSchema.safeParse(dataToValidate)
+  console.log('dataToValidate', dataToValidate)
 
+  const newsletterParsed = newsletterSchema.safeParse(dataToValidate)
+  console.log('newsletterParsed.success', newsletterParsed.error)
   if (!newsletterParsed.success) {
     return {
       ok: false,
@@ -69,7 +76,7 @@ export const createUpdateNewsletter = async (formData: FormData) => {
 
   const newsletterData = newsletterParsed.data
 
-  const { title, month, socialSkill, notes, vocabularies, topics, videos, id, grade } = newsletterData
+  const { title, month, socialSkill, notes, vocabularies, topics, videos, id, grade, playlist } = newsletterData
 
   try {
     const prismaTx = await prisma.$transaction(async (tx) => {
@@ -85,6 +92,12 @@ export const createUpdateNewsletter = async (formData: FormData) => {
               upsert: {
                 update: socialSkill,
                 create: socialSkill
+              }
+            },
+            playlist: {
+              upsert: {
+                update: playlist,
+                create: playlist
               }
             },
             notes: {
@@ -128,6 +141,9 @@ export const createUpdateNewsletter = async (formData: FormData) => {
             month,
             socialSkill: {
               create: socialSkill
+            },
+            playlist: {
+              create: playlist
             },
             notes: {
               createMany: {
@@ -174,6 +190,7 @@ export const createUpdateNewsletter = async (formData: FormData) => {
       message: prismaTx.message
     }
   } catch (error) {
+    console.log('error', error)
     if (error instanceof PrismaClientKnownRequestError) {
       if (error.code === 'P2002') {
         // Unique constraint error

--- a/src/actions/newsletter/get-newsletter-by-title.ts
+++ b/src/actions/newsletter/get-newsletter-by-title.ts
@@ -14,7 +14,8 @@ export const getNewsletterByTitle = async (title: string, grade?: Grade) => {
       vocabularies: true,
       videos: true,
       notes: true,
-      socialSkill: true
+      socialSkill: true,
+      playlist: true
     }
   })
 

--- a/src/actions/newsletter/get-newsletters.ts
+++ b/src/actions/newsletter/get-newsletters.ts
@@ -20,7 +20,8 @@ export const getNewsletters = async ({ page = 1, take = 6, grade }: PaginationOp
     take,
     skip: (page - 1) * take,
     include: {
-      topics: true
+      topics: true,
+      playlist: true
     },
     orderBy: {
       month: 'desc'

--- a/src/app/(educational-newsletters)/admin/newsletters/[slug]/FormNewsletter.tsx
+++ b/src/app/(educational-newsletters)/admin/newsletters/[slug]/FormNewsletter.tsx
@@ -13,7 +13,7 @@ import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '
 import { Input } from '@/components/ui/input'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Textarea } from '@/components/ui/textarea'
-import { type INewsletter } from '@/interfaces'
+import { type Newsletter } from '@/interfaces'
 
 const formSchema = z.object({
   title: z.string().min(2, {
@@ -43,13 +43,16 @@ const formSchema = z.object({
   })),
   grade: z.enum(['K2', 'K3'], {
     message: 'Grade must be K2 or K3.'
+  }),
+  playlist: z.object({
+    url: z.string().url('Must be a valid URL.')
   })
 })
 
 type FormValues = z.infer<typeof formSchema>
 
 interface NewsletterFormProps {
-  newsletter?: INewsletter
+  newsletter?: Newsletter
 }
 
 export default function NewsletterForm({ newsletter }: NewsletterFormProps) {
@@ -64,7 +67,8 @@ export default function NewsletterForm({ newsletter }: NewsletterFormProps) {
     vocabulary: newsletter?.vocabularies.length ? newsletter.vocabularies : [{ word: '', pronunciation: '' }],
     topics: newsletter?.topics.length ? newsletter.topics : [{ name: '' }],
     videos: newsletter?.videos.length ? newsletter.videos : [{ title: '', by: '', url: '' }],
-    grade: newsletter?.grade ?? 'K2'
+    grade: newsletter?.grade ?? 'K2',
+    playlist: newsletter?.playlist ?? { title: '', url: '' }
   }
 
   const form = useForm<FormValues>({
@@ -106,6 +110,7 @@ export default function NewsletterForm({ newsletter }: NewsletterFormProps) {
       formData.append('topics', JSON.stringify(values.topics))
       formData.append('videos', JSON.stringify(values.videos))
       formData.append('grade', values.grade)
+      formData.append('playlist', JSON.stringify(values.playlist))
 
       const { ok, message } = await createUpdateNewsletter(formData)
 
@@ -370,6 +375,26 @@ export default function NewsletterForm({ newsletter }: NewsletterFormProps) {
             <div className='w-full flex justify-end'>
               <Button type="button" variant="outline" onClick={() => { appendVideo({ title: '', by: '', url: '' }) }}>Add Video</Button>
             </div>
+          </CardContent>
+
+          {/* Playlist */}
+          <CardHeader>
+            <CardTitle>Playlist</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <FormField
+              control={form.control}
+              name="playlist.url"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Url</FormLabel>
+                  <FormControl>
+                    <Input placeholder="Playlist Url" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
           </CardContent>
 
           <CardFooter>

--- a/src/app/(educational-newsletters)/newsletters/[slug]/page.tsx
+++ b/src/app/(educational-newsletters)/newsletters/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import { type Metadata, type ResolvingMetadata } from 'next'
 import Link from 'next/link'
 import { redirect } from 'next/navigation'
+import { IoLogoYoutube } from 'react-icons/io5'
 import { getNewsletterByTitle, getAllNewslettersOrderedByMonth } from '@/actions/newsletter'
 import { Button } from '@/components/ui/button'
 import { convertToGrade } from '@/utils/convertToGrade'
@@ -226,6 +227,22 @@ export default async function NewsletterPage({ params, searchParams }: Props) {
             </ul>
           </div>
         </div>
+
+        {/* YouTube Playlist Button */}
+        <Button
+          variant="default"
+          className={`w-full ${headerColor} text-white`}
+          asChild
+        >
+          <Link
+            href={newsletter.playlist?.url ?? ''}
+            target="_blank"
+            className="flex items-center justify-center gap-2"
+          >
+            <IoLogoYoutube className="w-5 h-5" />
+            Play list
+          </Link>
+        </Button>
       </div>
     </div >
   )

--- a/src/app/(educational-newsletters)/page.tsx
+++ b/src/app/(educational-newsletters)/page.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link'
+import { IoLogoYoutube, IoArrowForward } from 'react-icons/io5'
 import { getNewsletters } from '@/actions/newsletter/get-newsletters'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'
@@ -44,10 +45,26 @@ export default async function LandingPage() {
                     <span key={topic.name}>{topic.name}, </span>
                   ))}</p>
                 </CardContent>
-                <CardFooter>
+                <CardFooter className='space-x-2'>
                   <Link href={`/newsletters/${newsletter.title}?grade=${newsletter.grade}`} passHref>
-                    <Button>View More</Button>
+                    <Button
+                      className='flex items-center justify-center gap-2'
+                      type='button'
+                    >
+                      <IoArrowForward className="w-5 h-5" />
+                      View More
+                    </Button>
                   </Link>
+                  <Button
+                    variant="secondary"
+                    className="flex items-center justify-center gap-2"
+                    asChild
+                  >
+                    <Link href={newsletter.playlist?.url ?? ''} target="_blank">
+                      <IoLogoYoutube className="w-5 h-5" />
+                      Play list
+                    </Link>
+                  </Button>
                 </CardFooter>
               </Card>
             ))
@@ -89,10 +106,20 @@ export default async function LandingPage() {
                     <span key={topic.name}>{topic.name}, </span>
                   ))}</p>
                 </CardContent>
-                <CardFooter>
+                <CardFooter className='space-x-2'>
                   <Link href={`/newsletters/${newsletter.title}?grade=${newsletter.grade}`} passHref>
                     <Button>View More</Button>
                   </Link>
+                  <Button
+                    variant="secondary"
+                    className="flex items-center justify-center gap-2"
+                    asChild
+                  >
+                    <Link href={newsletter.playlist?.url ?? ''} target="_blank">
+                      <IoLogoYoutube className="w-5 h-5" />
+                      Play list
+                    </Link>
+                  </Button>
                 </CardFooter>
               </Card>
             ))

--- a/src/interfaces/newsletter/newsletter.interface.ts
+++ b/src/interfaces/newsletter/newsletter.interface.ts
@@ -2,23 +2,29 @@ import { type ITopic, type IVocabulary, type IVideo } from '@/interfaces'
 
 export type Grade = 'K2' | 'K3'
 
-export interface ISocialSkill {
+export interface SocialSkill {
   skill: string
   activity: string
 }
 
-export interface INote {
+export interface Note {
   content: string
 }
 
-export interface INewsletter {
+export interface playlist {
+  title: string
+  url: string
+}
+
+export interface Newsletter {
   id: string
   title: string
   month: Date
-  socialSkill: ISocialSkill | null
+  socialSkill: SocialSkill | null
   vocabularies: IVocabulary[]
   topics: ITopic[]
   videos: IVideo[]
-  notes: INote[]
+  notes: Note[]
   grade: Grade
+  playlist: playlist | null
 }

--- a/src/seed/seed-add-videos-vocabulary.ts
+++ b/src/seed/seed-add-videos-vocabulary.ts
@@ -1,0 +1,106 @@
+import prisma from '../lib/prisma'
+
+async function main() {
+  const newsletterId = '0f3b9d1f-a644-4c5a-92e4-0b7ef3c3e4bb'
+
+  const videos = [
+    {
+      title: "Count Together by 10's | Counting Workout for Kids",
+      by: 'Jack Hartmann Kids Music Channel',
+      url: 'https://www.youtube.com/watch?v=W8CEOlAOGas',
+      newsletterId
+    },
+    {
+      title: 'Count by 10s | Number Songs',
+      by: 'Baby Shark - Pinkfong Kids’ Song & Stories',
+      url: 'https://www.youtube.com/watch?v=PYNqWmkkxaY',
+      newsletterId
+    },
+    {
+      title: 'Counting To 100 by 1s | Counting Numbers',
+      by: 'Dream English Kids',
+      url: 'https://www.youtube.com/watch?v=SxgCA1qOW20&t=3s',
+      newsletterId
+    },
+    {
+      title: 'Big Numbers Song | Count to 100 Song',
+      by: 'The Singing Walrus - English Songs For Kids',
+      url: 'https://www.youtube.com/watch?v=bGetqbqDVaA',
+      newsletterId
+    },
+    {
+      title: 'Alphabet Phonics Chant | Learning ABC Phonics for Kids',
+      by: 'Tora the Teacher',
+      url: 'https://www.youtube.com/watch?v=XAXyskFDYXw&t=22s',
+      newsletterId
+    },
+    {
+      title: 'How Old Are You? 🎶 | We Are Not Babies!',
+      by: 'Wormhole Learning',
+      url: 'https://www.youtube.com/watch?v=Ui932qk1_II',
+      newsletterId
+    }
+  ]
+
+  await prisma.video.createMany({
+    data: videos,
+    skipDuplicates: true // Skips if a duplicate entry exists
+  })
+
+  // eslint-disable-next-line no-console
+  console.log('Video data seeded successfully!')
+
+  const words = [
+    { word: 'Sweater', pronunciation: 'Suerer', newsletterId },
+    { word: 'Cold', pronunciation: 'Cold', newsletterId },
+    { word: 'Ice', pronunciation: 'Ais', newsletterId },
+    { word: 'Snowflake', pronunciation: 'Snoufleik', newsletterId },
+    { word: 'Igloo', pronunciation: 'Iiglu', newsletterId },
+    { word: 'Mirror', pronunciation: 'Miror', newsletterId },
+    { word: 'Milk', pronunciation: 'Milk', newsletterId },
+    { word: 'Mop', pronunciation: 'Mop', newsletterId },
+    { word: 'Mouse', pronunciation: 'Maus', newsletterId },
+    { word: 'Monkey', pronunciation: 'Monki', newsletterId },
+    { word: 'Moon', pronunciation: 'Mun', newsletterId },
+    { word: 'Kite', pronunciation: 'Kait', newsletterId },
+    { word: 'Kid', pronunciation: 'Kid', newsletterId },
+    { word: 'Koala', pronunciation: 'Koala', newsletterId },
+    { word: 'King', pronunciation: 'King', newsletterId },
+    { word: 'Key', pronunciation: 'Ki', newsletterId },
+    { word: 'Kangaroo', pronunciation: 'Kangaru', newsletterId },
+    { word: 'Jar', pronunciation: 'Yar', newsletterId },
+    { word: 'Jeans', pronunciation: 'Yins', newsletterId },
+    { word: 'Juice', pronunciation: 'Yus', newsletterId },
+    { word: 'Jacket', pronunciation: 'Yaket', newsletterId },
+    { word: 'Jam', pronunciation: 'Yam', newsletterId },
+    { word: 'Jellyfish', pronunciation: 'Yelifish', newsletterId },
+    { word: 'Fox', pronunciation: 'Fox', newsletterId },
+    { word: 'Fish', pronunciation: 'Fish', newsletterId },
+    { word: 'Flower', pronunciation: 'Flauer', newsletterId },
+    { word: 'Frog', pronunciation: 'Frog', newsletterId },
+    { word: 'Flag', pronunciation: 'Flag', newsletterId },
+    { word: 'Fork', pronunciation: 'Fork', newsletterId }
+  ]
+
+  await prisma.vocabulary.createMany({
+    data: words,
+    skipDuplicates: true // Optional: Skip if a duplicate entry exists
+  })
+
+  // eslint-disable-next-line no-console
+  console.log('Vocabulary data seeded successfully!')
+}
+
+(() => {
+  if (process.env.NODE_ENV === 'production') return
+
+  main()
+    .catch(e => {
+      // eslint-disable-next-line no-console
+      console.error(e)
+      process.exit(1)
+    })
+    .finally(async () => {
+      await prisma.$disconnect()
+    })
+})()


### PR DESCRIPTION
Introduced a new `Playlist` model to the database schema and integrated playlist functionality into the newsletters feature. Updated forms, interfaces, and queries to handle playlist data. Added UI elements for displaying and linking to YouTube playlists on newsletters.

Enhances newsletters with the ability to associate and display relevant video playlists, improving content accessibility and engagement.