### PR TITLE
fix: correct menu link to use ID instead of title

### DIFF
--- a/src/app/(educational-newsletters)/admin/breakfasts/page.tsx
+++ b/src/app/(educational-newsletters)/admin/breakfasts/page.tsx
@@ -395,7 +395,7 @@ export default function BreakfastPage() {
                         }
                       </div>
 
-                      <Link href={`/breakfasts/${menuItem.title}`}>
+                      <Link href={`/breakfasts/${menuItem.id}`}>
                         <div className="flex items-center justify-between">
                           <p className="text-sm font-medium text-primary truncate">
                             {menuItem.title}


### PR DESCRIPTION
- Updated the `Link` component in the admin breakfasts page to use `menuItem.id` instead of `menuItem.title` for generating dynamic URLs.
- Ensures proper routing and prevents potential conflicts or errors caused by duplicate or special characters in titles.