### PR TITLE
chore: 🎉 update holiday seed for 2025-2026

### DIFF
--- a/src/seed/seed-add-holiday.ts
+++ b/src/seed/seed-add-holiday.ts
@@ -3,74 +3,70 @@ import { PrismaClient } from '@prisma/client'
 const prisma = new PrismaClient()
 
 async function main() {
-  // Array of holidays for 2025
+  console.log('Eliminando días festivos existentes...')
+  await prisma.holiday.deleteMany() // borra todo lo que haya
+  console.log('Registros eliminados.')
+
+  // Array of holidays for 2025-2026
   const holidays = [
-    { name: 'Inicio de ciclo', date: new Date('2024-08-26') },
-    // Septiembre 2024
-    { name: 'Aniversario de la Independencia de México', date: new Date('2024-09-16') },
-    { name: 'Consejo Técnico', date: new Date('2024-09-27') },
-
-    // Octubre 2024
-    { name: 'Consejo Técnico', date: new Date('2024-10-25') },
-
-    // Noviembre 2024
-    { name: 'Aniversario de la Revolución Mexicana', date: new Date('2024-11-18') },
-    { name: 'Consejo Técnico', date: new Date('2024-11-29') },
-
-    // Diciembre 2024 - Vacaciones de Invierno
-    { name: 'Navidad', date: new Date('2024-12-25') },
-    { name: 'Vacaciones de Invierno', date: new Date('2024-12-19') },
-    { name: 'Vacaciones de Invierno', date: new Date('2024-12-20') },
-    { name: 'Vacaciones de Invierno', date: new Date('2024-12-23') },
-    { name: 'Vacaciones de Invierno', date: new Date('2024-12-24') },
-    { name: 'Vacaciones de Invierno', date: new Date('2024-12-26') },
-    { name: 'Vacaciones de Invierno', date: new Date('2024-12-27') },
-
-    // Enero 2025 - Vacaciones y Consejo Técnico
-    { name: 'Año Nuevo', date: new Date('2025-01-01') },
-    { name: 'Vacaciones de Invierno', date: new Date('2025-01-02') },
-    { name: 'Vacaciones de Invierno', date: new Date('2025-01-03') },
-    { name: 'Vacaciones de Invierno', date: new Date('2025-01-06') },
-    { name: 'Vacaciones de Invierno', date: new Date('2025-01-07') },
-    { name: 'Vacaciones de Invierno', date: new Date('2025-01-08') },
-    { name: 'Consejo Técnico', date: new Date('2025-01-31') },
-
-    // Febrero 2025
-    { name: 'Consejo Técnico', date: new Date('2025-02-27') },
-    { name: 'Corso infantil', date: new Date('2025-02-28') },
-    { name: 'Consejo Técnico', date: new Date('2025-02-28') }, // Está repetido en la lista original, lo dejo por si acaso
-
-    // Marzo 2025
-    { name: 'Carnaval', date: new Date('2025-03-03') },
-    { name: 'Carnaval', date: new Date('2025-03-04') },
-    { name: 'Natalicio de Benito Juárez', date: new Date('2025-03-21') },
-    { name: 'Consejo Técnico', date: new Date('2025-03-28') },
-
-    // Abril 2025 - Vacaciones de Semana Santa
-    { name: 'Vacaciones de Semana Santa', date: new Date('2025-04-14') },
-    { name: 'Vacaciones de Semana Santa', date: new Date('2025-04-15') },
-    { name: 'Vacaciones de Semana Santa', date: new Date('2025-04-16') },
-    { name: 'Vacaciones de Semana Santa', date: new Date('2025-04-17') },
-    { name: 'Viernes Santo', date: new Date('2025-04-18') },
-    { name: 'Sábado de Gloria', date: new Date('2025-04-19') },
-    { name: 'Domingo de Resurrección', date: new Date('2025-04-20') },
-    { name: 'Vacaciones de Semana Santa', date: new Date('2025-04-21') },
-    { name: 'Vacaciones de Semana Santa', date: new Date('2025-04-22') },
-    { name: 'Vacaciones de Semana Santa', date: new Date('2025-04-23') },
-    { name: 'Vacaciones de Semana Santa', date: new Date('2025-04-24') },
-    { name: 'Vacaciones de Semana Santa', date: new Date('2025-04-25') },
-
-    // Mayo 2025
-    { name: 'Día del Trabajo', date: new Date('2025-05-01') },
-    { name: 'Día de la Madre', date: new Date('2025-05-02') },
-    { name: 'Aniversario de la Batalla de Puebla', date: new Date('2025-05-05') },
-    { name: 'Día del Maestro', date: new Date('2025-05-15') },
-    { name: 'Día del Estudiante', date: new Date('2025-05-16') },
-    { name: 'Consejo Técnico', date: new Date('2025-05-30') },
-
-    // Junio 2025
-    { name: 'Fin de Curso Escolar', date: new Date('2025-06-27') }
-
+    { name: 'Inicio de ciclo', date: new Date('2025-09-01') },
+    // Septiembre 2025
+    { name: 'Aniversario de la Independencia de México', date: new Date('2025-09-16') },
+    { name: 'Consejo Técnico', date: new Date('2025-09-26') },
+    // Octubre 2025
+    { name: 'Consejo Técnico', date: new Date('2025-10-31') },
+    // Noviembre 2025
+    { name: 'Aniversario de la Revolución Mexicana', date: new Date('2025-11-17') },
+    { name: 'Consejo Técnico', date: new Date('2025-11-28') },
+    // Diciembre 2025 - Vacaciones de Invierno
+    { name: 'Vacaciones de Invierno', date: new Date('2025-12-22') },
+    { name: 'Vacaciones de Invierno', date: new Date('2025-12-23') },
+    { name: 'Vacaciones de Invierno', date: new Date('2025-12-24') },
+    { name: 'Navidad', date: new Date('2025-12-25') },
+    { name: 'Vacaciones de Invierno', date: new Date('2025-12-26') },
+    { name: 'Vacaciones de Invierno', date: new Date('2025-12-29') },
+    { name: 'Vacaciones de Invierno', date: new Date('2025-12-30') },
+    { name: 'Vacaciones de Invierno', date: new Date('2025-12-31') },
+    // Enero 2026 - Vacaciones y Consejo Técnico
+    { name: 'Año Nuevo', date: new Date('2026-01-01') },
+    { name: 'Vacaciones de Invierno', date: new Date('2026-01-02') },
+    { name: 'Vacaciones de Invierno', date: new Date('2026-01-05') },
+    { name: 'Vacaciones de Invierno', date: new Date('2026-01-06') },
+    { name: 'Vacaciones de Invierno', date: new Date('2026-01-07') },
+    { name: 'Vacaciones de Invierno', date: new Date('2026-01-08') },
+    { name: 'Vacaciones de Invierno', date: new Date('2026-01-09') },
+    { name: 'Consejo Técnico', date: new Date('2026-01-30') },
+    // Febrero 2026
+    { name: 'Día de la Constitución', date: new Date('2026-02-02') },
+    { name: 'Corso infantil', date: new Date('2026-02-13') },
+    { name: 'Carnaval', date: new Date('2026-02-16') },
+    { name: 'Carnaval', date: new Date('2026-02-17') },
+    { name: 'Consejo Técnico', date: new Date('2026-02-27') },
+    // Marzo 2026
+    { name: 'Natalicio de Benito Juárez', date: new Date('2026-03-16') },
+    { name: 'Consejo Técnico', date: new Date('2026-03-27') },
+    { name: 'Vacaciones de Semana Santa', date: new Date('2026-03-30') },
+    { name: 'Vacaciones de Semana Santa', date: new Date('2026-03-31') },
+    // Abril 2026 - Vacaciones de Semana Santa
+    { name: 'Vacaciones de Semana Santa', date: new Date('2026-04-01') },
+    { name: 'Vacaciones de Semana Santa', date: new Date('2026-04-02') },
+    { name: 'Viernes Santo', date: new Date('2026-04-03') },
+    { name: 'Sábado de Gloria', date: new Date('2026-04-04') },
+    { name: 'Domingo de Resurrección', date: new Date('2026-04-05') },
+    { name: 'Vacaciones de Semana Santa', date: new Date('2026-04-06') },
+    { name: 'Vacaciones de Semana Santa', date: new Date('2026-04-07') },
+    { name: 'Vacaciones de Semana Santa', date: new Date('2026-04-08') },
+    { name: 'Vacaciones de Semana Santa', date: new Date('2026-04-09') },
+    { name: 'Vacaciones de Semana Santa', date: new Date('2026-04-10') },
+    // Mayo 2026
+    { name: 'Día del Trabajo', date: new Date('2026-05-01') },
+    { name: 'Aniversario de la Batalla de Puebla', date: new Date('2026-05-05') },
+    { name: 'Día del Maestro', date: new Date('2026-05-15') },
+    { name: 'Consejo Técnico', date: new Date('2026-05-29') },
+    // Junio 2026
+    { name: 'Consejo Técnico', date: new Date('2026-06-26') },
+    // Julio 2026
+    { name: 'Fin de Curso Escolar', date: new Date('2026-07-15') }
   ]
 
   // eslint-disable-next-line no-console


### PR DESCRIPTION
### Changes Made
- chore: 🎉 update holidays array to cover 2025-2026
- chore: 🎨 adjust holiday dates including winter and Easter breaks

### Description of Changes
- Updated the `seed-add-holiday.ts` script to include all official holidays, school breaks, and technical council days for the academic years 2025-2026.
- Replaced previous 2024-2025 dates with the new dates for September 2025 through July 2026.
- Ensures that Prisma seeds will correctly populate the database with upcoming holiday data.